### PR TITLE
chore: add dotfile support to copy:main task

### DIFF
--- a/app/templates/_Gruntfile.coffee
+++ b/app/templates/_Gruntfile.coffee
@@ -127,6 +127,7 @@ module.exports = (grunt) ->
       main:
         files: [
           expand: true
+          dot: true
           cwd:'public/'
           src: ["**"]
           dest: "dist/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-mg",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Mg is the starting point for all frontend projects at Sparkbox",
   "keywords": [
     "yeoman-generator", "sparkbox", "mg", "project-init"


### PR DESCRIPTION
Adds support to the grunt `clean:main` task to also copy dotfiles. This is needed because the `.htaccess` file usually lives in the public folder, and needs to be copied to dist during the copy task.
