### PR TITLE
Update projectName prompt to be a full sentence

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,7 +24,7 @@ MgGenerator.prototype.askFor = function askFor() {
 
   var prompts = [{
     name: 'projectName',
-    message: 'Would you like to call this project?',
+    message: 'What would you like to call this project?',
   }];
 
   this.prompt(prompts, function (props) {


### PR DESCRIPTION
Was looking at your front-end generator for some tips and noticed that the prompt to name the project didn't read as a full sentence. Won't make too much of a difference but worth the small change perhaps?
